### PR TITLE
introduce multi-path configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ plug Plug.QuietLogger, path: "/api/status"
 
 You can also pass a list of paths to filter out, like:
 
-```
+```elixir
 plug Plug.QuietLogger, path: [ "/api/status", "/api/readiness" ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,17 @@ end
 Once that's done you can replace `Plug.Logger` with `Plug.QuietLogger` in your
 `endpoint.ex` file and you're ready to go.
 
-If you need to customize the request path you want to suppress logging for, you 
+If you need to customize the request path you want to suppress logging for, you
 can pass it with the `plug` call:
 
 ```elixir
 plug Plug.QuietLogger, path: "/api/status"
+```
+
+You can also pass a list of paths to filter out, like:
+
+```
+plug Plug.QuietLogger, path: [ "/api/status", "/api/readiness" ]
 ```
 
 If you want to change your logging level you can also set it the same way you

--- a/lib/plug/quiet_logger.ex
+++ b/lib/plug/quiet_logger.ex
@@ -8,13 +8,8 @@ defmodule Plug.QuietLogger do
     %{log: log, path: path}
   end
 
-  def call(%{request_path: path} = conn, %{log: :info, path: paths}) when is_list(paths) do
-    cond do
-      path in paths -> conn
-      true -> Plug.Logger.call(conn, :info)
-    end
-
-    conn
+  def call(%{request_path: path} = conn, %{log: log, path: paths}) when is_list(paths) do
+    if path in paths, do: conn, else: Plug.Logger.call(conn, log)
   end
 
   def call(%{request_path: path} = conn, %{log: :info, path: path}), do: conn

--- a/lib/plug/quiet_logger.ex
+++ b/lib/plug/quiet_logger.ex
@@ -8,9 +8,18 @@ defmodule Plug.QuietLogger do
     %{log: log, path: path}
   end
 
+  def call(%{request_path: path} = conn, %{log: :info, path: paths}) when is_list(paths) do
+    cond do
+      path in paths -> conn
+      true -> Plug.Logger.call(conn, :info)
+    end
+
+    conn
+  end
+
   def call(%{request_path: path} = conn, %{log: :info, path: path}), do: conn
 
-  def call(conn,  %{log: log}) do
+  def call(conn, %{log: log}) do
     Plug.Logger.call(conn, log)
   end
 end


### PR DESCRIPTION
problem: 
- sometimes you might have more than one healthcheck, eg. in Kubernetes we have readiness / liveliness checks

solution: 
- extend the api to accept list of paths to ignore + tests